### PR TITLE
Building with GCC versions lower than 8

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -24,6 +24,10 @@ set(EXTERNAL_LIBS
     Boost::program_options
 )
 
+if(CMAKE_CXX_COMPILER_VERSION VERSION_LESS 9.1)
+    list(APPEND EXTERNAL_LIBS stdc++fs)
+endif()
+
 add_executable(${APP_NAME} ${INTERNAL_LIBS})
 target_link_libraries(${APP_NAME} PRIVATE ${EXTERNAL_LIBS})
 

--- a/src/app/application/application.cpp
+++ b/src/app/application/application.cpp
@@ -4,11 +4,20 @@
  * SPDX-License-Identifier: MIT
 */
 
-#include <filesystem>
 #include <iostream>
 #include <fstream>
 #include <memory>
 #include <stdexcept>
+
+#if __has_include(<filesystem>)
+#include <filesystem>
+namespace fs = std::filesystem;
+#elif __has_include(<experimental/filesystem>)
+#include <experimental/filesystem>
+namespace fs = std::experimental::filesystem;
+#else
+#error "Missing filesystem"
+#endif
 
 #include <boost/program_options.hpp>
 #include <fmt/format.h>
@@ -163,7 +172,7 @@ int Application::ExecuteConfig(const std::string& ConfigFile)
         ("zswap.accept_threhsold_percent", boost::program_options::value<std::string>(), "The threshold at which ZSwap would start accepting pages again after it became full.")
         ;
 
-    if (!std::filesystem::exists(ConfigFile)) throw std::invalid_argument("Configuration file does not exists!");
+    if (!fs::exists(ConfigFile)) throw std::invalid_argument("Configuration file does not exists!");
     std::ifstream ConfigFileFs(ConfigFile);
     boost::program_options::store(boost::program_options::parse_config_file(ConfigFileFs, *ConfigOptions), *Config);
     Config -> notify();

--- a/src/app/application/application.cpp
+++ b/src/app/application/application.cpp
@@ -172,7 +172,7 @@ int Application::ExecuteConfig(const std::string& ConfigFile)
         ("zswap.accept_threhsold_percent", boost::program_options::value<std::string>(), "The threshold at which ZSwap would start accepting pages again after it became full.")
         ;
 
-    if (!fs::exists(ConfigFile)) throw std::invalid_argument("Configuration file does not exists!");
+    if (!fs::exists(ConfigFile)) throw std::invalid_argument("Configuration file does not exist!");
     std::ifstream ConfigFileFs(ConfigFile);
     boost::program_options::store(boost::program_options::parse_config_file(ConfigFileFs, *ConfigOptions), *Config);
     Config -> notify();


### PR DESCRIPTION
Hi @xvitaly,

The [Installation Documentation](https://github.com/xvitaly/zswap-cli/blob/master/docs/installation.md) says that we can build zswap-cli with GCC 7.4++. However, I cannot compile the project on my machine running Ubuntu 18.04 LTS with GCC 7.5.0. The reasons are:

- C++17 features are available since GCC 5 but versions lower than 8 do not fully implement `<filesystem>`. In this case, we have to use `<experimental/filesystem>` instead [(gcc-8 changes).](https://gcc.gnu.org/gcc-8/changes.html#cxx)
- If we use `<experimental/filesystem>` with GCC versions lower than 9.1, we need to link the binary with `stdc++fs` library [(gcc-9 changes).](https://gcc.gnu.org/gcc-9/changes.html#cxx)

This pull request aims to fix this issue by selecting `<experimental/filesystem>` for GCC versions lower than 8, and linking with `stdc++fs` library when needed. However, because the usages of `std::filesystem` in this project is relatively small, we can consider replacing it with Linux's syscalls.

Thank you for reviewing this PR!



