### PR TITLE
Deprecated obtaining ZSwap options from the environment variables

### DIFF
--- a/assets/manpage/zswap-cli.md.in
+++ b/assets/manpage/zswap-cli.md.in
@@ -106,6 +106,8 @@ Supported values: **Y**, **N**.
 
 @APP_NAME@ support of getting options from the environment variables.
 
+**Warning! This feature is deprecated and will be removed in future versions. Please consider switching to configuration files or CLI options.**
+
 ## Supported options
 
   * **ZSWAP_ENABLED_VALUE** - enable or disable the ZSwap kernel module.

--- a/docs/environment-options.md
+++ b/docs/environment-options.md
@@ -2,6 +2,9 @@
 
 This project support of getting options from the environment variables.
 
+> [!WARNING]
+> This feature is deprecated and will be removed in future versions. Please consider switching to [configuration files](configuration-files.md) or [CLI options](using-application.md).
+
 ## Supported options
 
   * `ZSWAP_ENABLED_VALUE` - enable or disable the ZSwap kernel module.


### PR DESCRIPTION
Describe your changes below:

Deprecated obtaining ZSwap options from the environment variables.