### PR TITLE
 Enabled access to the `--stats` command-line option without super-user privileges

### DIFF
--- a/src/app/application/application.cpp
+++ b/src/app/application/application.cpp
@@ -286,8 +286,8 @@ int Application::Run() const
 {
     if (CmdLine -> empty() || CmdLine -> count("help")) return PrintHelp();
     if (CmdLine -> count("version")) return PrintVersion();
-    CheckIfRunningBySuperUser();
     if (CmdLine -> count("stats")) return PrintStats(CmdLine -> at("stats").as<int>());
+    CheckIfRunningBySuperUser();
     if (CmdLine -> count("config")) return ExecuteConfig(CmdLine -> at("config").as<std::string>());
     if (CmdLine -> count("env")) return ExecuteEnv();
     return ExecuteCmdLine();

--- a/src/app/application/application.cpp
+++ b/src/app/application/application.cpp
@@ -315,7 +315,7 @@ void Application::CheckIfPoolIsNotEmpty(const unsigned long PoolSize) const
 
 void Application::CheckIfModuleLoaded() const
 {
-    if (!ZSwap -> IsAvailable()) throw std::runtime_error("ZSwap kernel module is not loaded.");
+    if (!ZSwap -> IsAvailable()) throw std::runtime_error("ZSwap kernel module is not loaded or access to sysfs is denied.");
 }
 
 void Application::InitClassMembers()

--- a/src/lib/zswapdebug/zswapdebug.cpp
+++ b/src/lib/zswapdebug/zswapdebug.cpp
@@ -13,6 +13,7 @@
 #include <fstream>
 #include <optional>
 #include <string>
+#include <system_error>
 
 #include "zswapdebug/zswapdebug.hpp"
 

--- a/src/lib/zswapdebug/zswapdebug.cpp
+++ b/src/lib/zswapdebug/zswapdebug.cpp
@@ -93,5 +93,7 @@ std::optional<unsigned long> ZSwapDebug::GetIncompressiblePages() const
 
 bool ZSwapDebug::IsDebugAvailable() const
 {
-    return std::filesystem::exists(ModuleDebugPath);
+    std::error_code error;
+    std::filesystem::file_status status = std::filesystem::status(ModuleDebugPath, error);
+    return !error && std::filesystem::exists(status) && std::filesystem::is_directory(status);
 }

--- a/src/lib/zswapobject/zswapobject.cpp
+++ b/src/lib/zswapobject/zswapobject.cpp
@@ -17,6 +17,7 @@
 #include <regex>
 #include <stdexcept>
 #include <string>
+#include <system_error>
 
 #include "zswapobject/zswapobject.hpp"
 

--- a/src/lib/zswapobject/zswapobject.cpp
+++ b/src/lib/zswapobject/zswapobject.cpp
@@ -9,8 +9,8 @@
  * Contains the ZSwapObject class implementation.
 */
 
-#include <format>
 #include <filesystem>
+#include <format>
 #include <fstream>
 #include <iostream>
 #include <optional>

--- a/src/lib/zswapobject/zswapobject.cpp
+++ b/src/lib/zswapobject/zswapobject.cpp
@@ -172,5 +172,7 @@ void ZSwapObject::SetZSwapShrinkerEnabled(const std::string& Value) const
 
 bool ZSwapObject::IsAvailable() const
 {
-    return std::filesystem::exists(ZSwapModuleParametersPath);
+    std::error_code error;
+    std::filesystem::file_status status = std::filesystem::status(ZSwapModuleParametersPath, error);
+    return !error && std::filesystem::exists(status) && std::filesystem::is_directory(status);
 }


### PR DESCRIPTION
Describe your changes below:

Enabled access to the `--stats` command-line option without super-user privileges if the distribution allows users to access debugfs (99% of distributions don't).